### PR TITLE
Arregla contador de comentarios

### DIFF
--- a/components/user-editor/component.js
+++ b/components/user-editor/component.js
@@ -25,6 +25,7 @@ const StyledEditorWrapper = styled.div`
       font-size: 1.8rem;
       line-height: 1.89;
       color: #203340;
+      padding: 6.5px 0px;
     }
   }
 `
@@ -119,15 +120,18 @@ class UserEditor extends Component {
     return false
   }
 
+  updateMousePosition = (e) => {
+    this.setState({
+      top: e.pageY - 740,
+      left: e.pageX - 100
+    })
+  }
+
   onCommentHoverIn = (id) => (e) => {
-    const top = e.clientY - 200
-    const left = e.clientX - 100
     this.setState((prevState) => {
       return {
         showAddComment: false,
-        commentsIds: prevState.commentsIds.concat(id),
-        top: top,
-        left: left
+        commentsIds: prevState.commentsIds.concat(id)
       }
     })
   }
@@ -215,7 +219,7 @@ class UserEditor extends Component {
             left={this.state.left} />
         }
         <EditorTitle>Artículos de la propuesta</EditorTitle>
-        <div ref={this.myEditor}>
+        <div ref={this.myEditor} onMouseMove={this.updateMousePosition}>
           <Editor
             className='editor'
             schema={this.schema}

--- a/elements/comment-counter/component.js
+++ b/elements/comment-counter/component.js
@@ -14,8 +14,6 @@ const CounterWrapper = styled.div`
   border-radius: 5px;
   position: absolute;
   z-index: 100;
-  top: ${(props) => props.top + 'px'};
-  left: ${(props) => props.left + 'px'};
 
   &::after {
     content: '';
@@ -42,16 +40,19 @@ const CounterWrapper = styled.div`
 `
 
 const CommentCounter = (props) => (
-  <CounterWrapper top={props.top} left={props.left}>
+  <CounterWrapper style={{
+    top: props.top + 'px',
+    left: props.left + 'px'
+  }}>
     <span className='counter-span'>{props.count} aportes de usuarios</span>
     <span className='text-span'>click para abrir aportes</span>
   </CounterWrapper>
 )
 
 CommentCounter.propTypes = {
-  count: PropTypes.number.isRequired,
-  top: PropTypes.number.isRequired,
-  left: PropTypes.number.isRequired
+  count: PropTypes.number,
+  top: PropTypes.number,
+  left: PropTypes.number
 }
 
 export default CommentCounter


### PR DESCRIPTION
La posición estaba siendo establecido mediante styled-jsx lo que generaba codigo por cada vez que se movia el cursor, por eso use inline styles para eso.
Se ajusto como se consigue la posición del tooltip para que acompañe al cursor en todo momento y se uso las coordenadas `pageX` y `pageY` para tener una posición mas consistente.