### PR TITLE
Mejorar/estilos mobile

### DIFF
--- a/components/footer-bar/component.js
+++ b/components/footer-bar/component.js
@@ -11,6 +11,9 @@ const FooterBar = styled.div`
   display: flex;
   justify-content:center;
   margin-bottom: 2rem;
+  @media (max-width: 760px) {
+    margin-bottom: 6rem;
+  }
   > a {
     color: #2c4c61;
     display: inline-block;

--- a/components/participate-item/component.js
+++ b/components/participate-item/component.js
@@ -10,6 +10,11 @@ const ParticipateItem = styled.div`
   justify-content:space-between;
   align-items:center;
   box-sizing: border-box;
+  @media (max-width: 1060px) {
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+  }
   &:nth-child(even) {
       padding-left:1rem;
       padding-right:1rem;

--- a/components/project-comments/component.js
+++ b/components/project-comments/component.js
@@ -26,15 +26,15 @@ const StyledProjectComments = styled.div`
   `
 const StyledTitle = styled.div`
   width: 136px;
-  height: 16px;
-  font-size: 14px;
+  height: 1.6rem;
+  font-size: 1.4rem;
   font-family:var(--bold);
   color: #2c4c61;
   margin:2rem 0;
   `
-const StyledSubtitle = styled.div`;
-  height: 16px;
-  font-size: 14px;
+const StyledSubtitle = styled.div`
+  height: 1.6rem;
+  font-size: 1.4rem;
   color: #9b9b9b;
   margin:2rem 0;
 `

--- a/components/project-header/component.js
+++ b/components/project-header/component.js
@@ -47,7 +47,7 @@ const ProjectHeader = ({ project, section }) => (
       section={section} />
     <ProjectHeaderWrapper>
       <TopBarWrapper>
-        <UserAvatar
+        <UserAvatar headerbar
           authorId={project.author._id}
           avatarImg={project.author.avatar}
           name={project.author.fullname}

--- a/components/project-header/component.js
+++ b/components/project-header/component.js
@@ -30,9 +30,12 @@ const TopBarWrapper = styled.div`
   flex-direction:row;
   justify-content:space-between;
   & > div {
-    padding: 0 30px;
+    padding: 0 3rem;
     border-right: 1px solid #e9e9e9;
     height: 50px;
+  }
+  & > div:first-child {
+    padding-left:0px;
   }
   & > div:last-child {
     border-right: none;

--- a/components/user-menu/component.js
+++ b/components/user-menu/component.js
@@ -5,6 +5,10 @@ import styled from 'styled-components'
 const StyledUl = styled.ul`
   width: 200px;
   height: 104px; /* 154px */
+  @media (max-width: 760px) {
+    width: 150px;
+    height: 74px;
+  }
   box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.05);
   border: solid 1px #e9e9e9;
   background-color: #f6f6f6;

--- a/elements/about-text/component.js
+++ b/elements/about-text/component.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 
 const StyledText = styled.div`
   padding-left: 8%;
+  padding-right: 8%;
   padding-top: 6.8rem;
   padding-bottom: 8%;
   width: 50%;

--- a/elements/navbar-logo/component.js
+++ b/elements/navbar-logo/component.js
@@ -16,6 +16,11 @@ const Logo = styled.div`
   background-position: center;  
   box-sizing: border-box;
   cursor:pointer;
+  @media (max-width: 760px) {
+    width: 67px;
+    height: 51px;
+    margin-top:auto;
+  }
 `
 
 const NavbarLogo = () => (

--- a/elements/navbar-usermenu/component.js
+++ b/elements/navbar-usermenu/component.js
@@ -37,7 +37,7 @@ padding-left:10px;
 display:flex;
 flex-direction:column;
 justify-content:space-between;
-@media (max-width: 460px) {
+@media (max-width: 660px) {
     display:none;
   }
 `

--- a/elements/navbar-usermenu/component.js
+++ b/elements/navbar-usermenu/component.js
@@ -29,11 +29,17 @@ text-transform:uppercase;
 `
 const TextWrapper = styled.div`
 height:35px;
+@media (max-width: 760px) {
+    height:25px;
+  }
 margin-top:0px;
 padding-left:10px;
 display:flex;
 flex-direction:column;
 justify-content:space-between;
+@media (max-width: 460px) {
+    display:none;
+  }
 `
 const Arrow = styled.i`
   margin:5px 0px 0px 15px;

--- a/elements/secondary-navbar-title/component.js
+++ b/elements/secondary-navbar-title/component.js
@@ -4,6 +4,9 @@ import styled from 'styled-components'
 const StyledSecondaryNavbarTitle = styled.h2`
   font-size: 2rem;
   color: #101a21;
+  @media (max-width: 640px) {
+    font-size: 1.5rem;
+  }
 `
 const Span = styled.span`
   font-family: var(--bold);

--- a/elements/user-avatar/component.js
+++ b/elements/user-avatar/component.js
@@ -8,6 +8,7 @@ display:flex;
 align-items:flex-start;
 text-align:left;
 margin-bottom:2rem;
+min-width:200px;
 `
 const Avatar = styled.div`
   width: 40px;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -67,6 +67,9 @@ injectGlobal`
     --lined: calc(width/22);
 
     font-size: 10px;
+    @media (max-width: 760px) {
+    font-size: 7px;
+  }
   }
 
   * {


### PR DESCRIPTION
Cierra #91 y mejora los estilos generales para pantallas pequeñas.
Hay que checkear con diseño algunas implementaciones para mobile, como la del header de proyecto que aún no fue propuesto.